### PR TITLE
Revert backend to 5 runners up until the frontend is updated

### DIFF
--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -2,7 +2,7 @@ const { get } = require('lodash');
 
 const { DB } = require('../db');
 
-const RUNNER_UPS = 10;
+const RUNNER_UPS = 5;
 
 const ALWAYS_FIELDS = { 'owner': 1 };
 


### PR DESCRIPTION
The following commit has not taken effect in production yet: https://github.com/IdleLands/Global/commit/0bc72fa5e32cc3310771b1d48306adfa81ba042b

This causes the rankings to overflow the boxes on the website. In the meantime, I suggest we revert the leader board back to being a top 5.